### PR TITLE
Controllo CPU e RAM tramite systemd. Riavvio periodico

### DIFF
--- a/iorestoacasa_metrics.service
+++ b/iorestoacasa_metrics.service
@@ -4,12 +4,20 @@ Description=Io Resto A Casa Jitsi metrics exporter
 [Service]
 Type=simple
 ExecStart=/usr/bin/python IORESTOACASA_PLACEHOLDER
+# tempo di pausa tra arresto e avvio del servizio
 RestartSec=60
+# se bloccato da un timeout o da un errore, lo riavvia, sempre
 Restart=always
 KillSignal=SIGTERM
 StandardError=syslog
 NotifyAccess=all
 SendSIGKILL=no
+# attiva il controllo della memoria occupata da questo servizio
+MemoryAccounting=true
+# limita la memoria totale a 50Mb (vale solo se MemoryAccounting è attuivo)
+MemoryMax=50M
+# limita il servizio ad un massimo di due processi contemporanei
+LimitNPROC=2
 
 [Install]
 WantedBy=multi-user.target

--- a/iorestoacasa_metrics.service
+++ b/iorestoacasa_metrics.service
@@ -6,6 +6,8 @@ Type=simple
 ExecStart=/usr/bin/python IORESTOACASA_PLACEHOLDER
 # tempo di pausa tra arresto e avvio del servizio
 RestartSec=60
+# blocca il servizio dopo 6 ore che è attivo, anche se senza problemi
+RuntimeMaxSec=21600
 # se bloccato da un timeout o da un errore, lo riavvia, sempre
 Restart=always
 KillSignal=SIGTERM


### PR DESCRIPTION
Nelle ultime settimane ho trovato più volte che il servizio era attivo (lo stato in systemd era giusto), ma non funzionante. L'unica soluzione era quella di riavviarlo.
Con questi due commit aggiungo il riavvio automatico ogni 6 ore e il controllo delle risorse: al servizio sono dati al massimo 2 processi concorrenti e 50mb di memoria.