### PR TITLE
scartata la nuova metrica tossedPacketsEnergy'

### DIFF
--- a/iorestoacasa_metrics.py
+++ b/iorestoacasa_metrics.py
@@ -22,7 +22,9 @@ def is_skippable(key):
         'graceful_shutdown',
         'conferences_by_audio_senders',
         'conferences_by_video_senders',
-        'version']
+        'version',
+        'tossedPacketsEnergy'
+    ]
     return True if key in skippable_keys else False
 
 @route("/<url:re:.+>")


### PR DESCRIPTION
In jitsi è stata recentemente aggiunta la metrica tossedPacketsEnergy che non è gestita correttamente da grafana.
Per questo qui viene scartata.